### PR TITLE
Change MasterCPUUtilization evaluation period to 5 minutes

### DIFF
--- a/OpenSearch_cloudwatch_alarms.yaml
+++ b/OpenSearch_cloudwatch_alarms.yaml
@@ -281,7 +281,7 @@ Resources:
       MetricName: 'MasterCPUUtilization'
       ComparisonOperator: GreaterThanOrEqualToThreshold   
       Threshold: 50
-      Period: 900
+      Period: 300
       EvaluationPeriods: 3
       # Action
       OKActions:


### PR DESCRIPTION
recommended alarm for MasterCPUUtilization is described as `MasterCPUUtilization maximum is >= 50% for 15 minutes, 3 consecutive times`  https://docs.aws.amazon.com/opensearch-service/latest/developerguide/cloudwatch-alarms.html

however, the resulting alarm is described in cloudwatch console as: `This alarm will trigger when the blue line goes above the red line for 3 datapoints within 45 minutes.` - this is proving to be too sensitive

This commit changes the evaluation period to 5 mintues, resulting in description: `This alarm will trigger when the blue line goes above the red line for 3 datapoints within 15 minutes.` which I think is more useful, and imo matches the description provided in aws docs.